### PR TITLE
fix(babel): Make babel to recognize TypeScript extensions in dev mode

### DIFF
--- a/lib/process/master.js
+++ b/lib/process/master.js
@@ -27,6 +27,11 @@ if (!('toJSON' in Error.prototype)) {
 process.on('message', function(msg) {
   switch (msg.cmd) {
     case 'init':
+      if (process.env.NODE_ENV !== 'production') {
+        require('@babel/register').default({
+          extensions: ['.js', '.jsx', '.ts', '.tsx']
+        });
+      }
       processor = require(msg.value);
       if (processor.default) {
         // support es2015 module.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
+    "@babel/register": "^7.7.7",
     "bluebird": "^3.5.3",
     "cron-parser": "^2.5.0",
     "debuglog": "^1.0.0",


### PR DESCRIPTION
This is to fix an issue with child process not inheriting the extensions
option passed to the babel cli.